### PR TITLE
Use full URL to fix broken links in the rendered Terraform doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # terraform-google-cloud-operations
 
 This module is a collection of submodules related to Google Cloud Operations (Logging and Monitoring):
-- [Agent Policy](./modules/agent-policy/README.md)
+- [Agent Policy](https://github.com/terraform-google-modules/terraform-google-cloud-operations/blob/master/modules/agent-policy/README.md)
 
 ## Usage
 
-Each submodule's usage is documented in the [modules](./modules) folder. Functional examples are included in the [examples](./examples/) directory.
+Each submodule's usage is documented in the [modules](https://github.com/terraform-google-modules/terraform-google-cloud-operations/blob/master/modules) folder. Functional examples are included in the [examples](https://github.com/terraform-google-modules/terraform-google-cloud-operations/blob/master/examples/) directory.
 
 ## Contributing
 
-Refer to the [contribution guidelines](./CONTRIBUTING.md) for
+Refer to the [contribution guidelines](https://github.com/terraform-google-modules/terraform-google-cloud-operations/blob/master/CONTRIBUTING.md) for
 information on contributing to this module.


### PR DESCRIPTION
The links in https://registry.terraform.io/modules/terraform-google-modules/cloud-operations/google/0.1.0 are broken because relative paths are used here.