### PR TITLE
Promote alpha to beta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.13.7
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.14.9
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -45,4 +45,4 @@ tags:
 - 'bats'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.7'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.14.9'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.7'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.14.9'

--- a/examples/agent_policy_detailed_example/README.md
+++ b/examples/agent_policy_detailed_example/README.md
@@ -6,8 +6,12 @@ This example illustrates how to use the `agent-policy` module.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
+
+## Outputs
+
+No output.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/agent_policy_simple_example/README.md
+++ b/examples/agent_policy_simple_example/README.md
@@ -6,8 +6,12 @@ This example illustrates how to use the `agent-policy` module.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
+
+## Outputs
+
+No output.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/agent_policy_update_example/README.md
+++ b/examples/agent_policy_update_example/README.md
@@ -6,14 +6,18 @@ This example is specifically for testing update functionality.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| agent\_rules | A list of agent rules to be enforced by the policy. | list(any) | n/a | yes |
-| description | The description of the policy. | string | `"null"` | no |
-| group\_labels | A list of label maps to filter instances to apply policies on. | object | `"null"` | no |
-| instances | A list of zones to filter instances to apply the policy. | list(string) | `"null"` | no |
-| os\_types | A list of label maps to filter instances to apply policies on. | list(any) | n/a | yes |
-| project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
-| zones | A list of zones to filter instances to apply the policy. | list(string) | `"null"` | no |
+|------|-------------|------|---------|:--------:|
+| agent\_rules | A list of agent rules to be enforced by the policy. | `list(any)` | n/a | yes |
+| description | The description of the policy. | `string` | `null` | no |
+| group\_labels | A list of label maps to filter instances to apply policies on. | `list(map(string))` | `null` | no |
+| instances | A list of zones to filter instances to apply the policy. | `list(string)` | `null` | no |
+| os\_types | A list of label maps to filter instances to apply policies on. | `list(any)` | n/a | yes |
+| project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
+| zones | A list of zones to filter instances to apply the policy. | `list(string)` | `null` | no |
+
+## Outputs
+
+No output.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/agent-policy/README.md
+++ b/modules/agent-policy/README.md
@@ -165,4 +165,4 @@ information on contributing to this module.
 [curl]: https://curl.haxx.se
 [google-cloud-sdk]: https://cloud.google.com/sdk/install
 [os-config-metadata]: https://cloud.google.com/compute/docs/manage-os#enable-metadata
-[ops-agents-policy-docs]: https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/ops-agents/policies/create
+[ops-agents-policy-docs]: https://cloud.google.com/sdk/gcloud/reference/beta/compute/instances/ops-agents/policies/create

--- a/modules/agent-policy/README.md
+++ b/modules/agent-policy/README.md
@@ -48,15 +48,19 @@ Functional examples are included in the [examples](./../../examples) directory.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| agent\_rules | A list of agent rules to be enforced by the policy. | list(any) | n/a | yes |
-| description | The description of the policy. | string | `"null"` | no |
-| group\_labels | A list of label maps to filter instances to apply policies on. | list(map(string)) | `"null"` | no |
-| instances | A list of instances to filter instances to apply the policy. | list(string) | `"null"` | no |
-| os\_types | A list of OS types to filter instances to apply the policy. | list(any) | n/a | yes |
-| policy\_id | The ID of the policy. | string | n/a | yes |
-| project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
-| zones | A list of zones to filter instances to apply the policy. | list(string) | `"null"` | no |
+|------|-------------|------|---------|:--------:|
+| agent\_rules | A list of agent rules to be enforced by the policy. | `list(any)` | n/a | yes |
+| description | The description of the policy. | `string` | `null` | no |
+| group\_labels | A list of label maps to filter instances to apply policies on. | `list(map(string))` | `null` | no |
+| instances | A list of instances to filter instances to apply the policy. | `list(string)` | `null` | no |
+| os\_types | A list of OS types to filter instances to apply the policy. | `list(any)` | n/a | yes |
+| policy\_id | The ID of the policy. | `string` | n/a | yes |
+| project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
+| zones | A list of zones to filter instances to apply the policy. | `list(string)` | `null` | no |
+
+## Outputs
+
+No output.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/agent-policy/main.tf
+++ b/modules/agent-policy/main.tf
@@ -19,7 +19,7 @@ module "gcloud-upsert" {
 
   platform              = "linux"
   additional_components = ["beta"]
-
+  gcloud_sdk_version    = "325.0.0"
   create_cmd_entrypoint = abspath("${path.module}/scripts/create-update-script.sh")
   create_cmd_body       = <<-EOT
     ${var.project_id} ${jsonencode(var.policy_id)} \
@@ -37,6 +37,7 @@ module "gcloud-destroy" {
   source = "terraform-google-modules/gcloud/google"
 
   platform              = "linux"
+  gcloud_sdk_version    = "325.0.0"
   additional_components = ["beta"]
 
   destroy_cmd_entrypoint = abspath("${path.module}/scripts/delete-script.sh")

--- a/modules/agent-policy/main.tf
+++ b/modules/agent-policy/main.tf
@@ -18,7 +18,7 @@ module "gcloud-upsert" {
   source = "terraform-google-modules/gcloud/google"
 
   platform              = "linux"
-  additional_components = ["alpha"]
+  additional_components = ["beta"]
 
   create_cmd_entrypoint = abspath("${path.module}/scripts/create-update-script.sh")
   create_cmd_body       = <<-EOT
@@ -37,7 +37,7 @@ module "gcloud-destroy" {
   source = "terraform-google-modules/gcloud/google"
 
   platform              = "linux"
-  additional_components = ["alpha"]
+  additional_components = ["beta"]
 
   destroy_cmd_entrypoint = abspath("${path.module}/scripts/delete-script.sh")
   destroy_cmd_body       = "${var.project_id} ${jsonencode(var.policy_id)}"

--- a/modules/agent-policy/scripts/script-utils.sh
+++ b/modules/agent-policy/scripts/script-utils.sh
@@ -23,7 +23,7 @@
 
 CREATE="create"
 UPDATE="update"
-LAUNCH_STAGE="alpha"
+LAUNCH_STAGE="beta"
 
 
 # Params:

--- a/test/agent-policy-tests/test-script-utils.bats
+++ b/test/agent-policy-tests/test-script-utils.bats
@@ -52,7 +52,7 @@ setup() {
     local zones_json="$EMPTY_LIST_JSON"
     local instances_json="$EMPTY_LIST_JSON"
 
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
     expected_command="$expected_command --os-types='version=8,short-name=centos'"
@@ -73,7 +73,7 @@ setup() {
     local zones_json="$EMPTY_LIST_JSON"
     local instances_json="$EMPTY_LIST_JSON"
 
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --description='an example test policy'"
     expected_command="$expected_command --agent-rules='type=metrics'"
@@ -97,7 +97,7 @@ setup() {
     local zones_json="$EMPTY_LIST_JSON"
     local instances_json="$EMPTY_LIST_JSON"
 
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='version=current-major,"
     expected_command="${expected_command}type=logging,enable-autoupgrade=true,"
@@ -121,7 +121,7 @@ setup() {
     local zones_json="$EMPTY_LIST_JSON"
     local instances_json="$EMPTY_LIST_JSON"
 
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
     expected_command="$expected_command --group-labels='product=myapp,env=prod;"
@@ -144,7 +144,7 @@ setup() {
     local zones_json="[\"us-central1-c\",\"asia-northeast2-b\",\"europe-north1-b\"]"
     local instances_json="$EMPTY_LIST_JSON"
 
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
     expected_command="$expected_command --os-types='version=8,short-name=centos'"
@@ -167,7 +167,7 @@ setup() {
     local zones_json="$EMPTY_LIST_JSON"
     local instances_json="[\"zones/us-central1-a/instances/test-instance\"]"
 
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
     expected_command="$expected_command --os-types='version=8,short-name=centos'"
@@ -196,7 +196,7 @@ setup() {
     local zones_json="$EMPTY_LIST_JSON"
     local instances_json="$EMPTY_LIST_JSON"
 
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies update ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
     expected_command="$expected_command --os-types='version=8,short-name=centos'"
@@ -220,7 +220,7 @@ setup() {
 ##############################################################
 
 @test "Test get_describe_command" {
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies describe ops-agents-test-policy"
     expected_command="$expected_command --project='test-project-id' --quiet"
 
@@ -235,7 +235,7 @@ setup() {
 ##############################################################
 
 @test "Test get_delete_command" {
-    local expected_command="gcloud alpha compute instances ops-agents"
+    local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies delete ops-agents-test-policy"
     expected_command="$expected_command --project='test-project-id' --quiet"
 

--- a/test/integration/agent_policy_detailed_example/controls/gcloud.rb
+++ b/test/integration/agent_policy_detailed_example/controls/gcloud.rb
@@ -23,7 +23,7 @@ control "gcloud" do
     its(:stdout) { should match "osconfig.googleapis.com" }
   end
 
-  describe command("gcloud alpha compute instances ops-agents policies describe " \
+  describe command("gcloud beta compute instances ops-agents policies describe " \
     "ops-agents-test-policy-detailed --project=#{attribute("project_id")} --quiet") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq "" }

--- a/test/integration/agent_policy_simple_example/controls/gcloud.rb
+++ b/test/integration/agent_policy_simple_example/controls/gcloud.rb
@@ -23,7 +23,7 @@ control "gcloud" do
     its(:stdout) { should match "osconfig.googleapis.com" }
   end
 
-  describe command("gcloud alpha compute instances ops-agents policies describe " \
+  describe command("gcloud beta compute instances ops-agents policies describe " \
     "ops-agents-test-policy-simple --project=#{attribute("project_id")} --quiet") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq "" }

--- a/test/integration/agent_policy_update_example/controls/gcloud.rb
+++ b/test/integration/agent_policy_update_example/controls/gcloud.rb
@@ -23,7 +23,7 @@ instances = attribute('instances')
 control "gcloud" do
   title "gcloud"
 
-  describe command("gcloud alpha compute instances ops-agents policies describe " \
+  describe command("gcloud beta compute instances ops-agents policies describe " \
     "ops-agents-test-policy-update --project=#{attribute("project_id")} " \
     "--quiet --format=json") do
     its(:exit_status) { should eq 0 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -23,7 +23,6 @@ module "project" {
   org_id               = var.org_id
   folder_id            = var.folder_id
   billing_account      = var.billing_account
-  skip_gcloud_download = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -18,11 +18,11 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0"
 
-  name                 = "ci-cloud-operations"
-  random_project_id    = "true"
-  org_id               = var.org_id
-  folder_id            = var.folder_id
-  billing_account      = var.billing_account
+  name              = "ci-cloud-operations"
+  random_project_id = "true"
+  org_id            = var.org_id
+  folder_id         = var.folder_id
+  billing_account   = var.billing_account
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 9.0"
+  version = "~> 10.0"
 
   name                 = "ci-cloud-operations"
   random_project_id    = "true"

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -23,5 +23,5 @@ provider "google" {
 }
 
 provider "google-beta" {
-  version = ">= 3.38.0"
+  version = ">= 3.54.0"
 }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -23,5 +23,5 @@ provider "google" {
 }
 
 provider "google-beta" {
-  version = "~> 3.25.0"
+  version = ">= 3.38.0"
 }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.25.0"
+  version = ">= 3.25.0"
 }
 
 provider "google-beta" {


### PR DESCRIPTION
gcloud beta compute instances ops-agents policies command is publicly available now. Adjusting the alpha command to beta command.

https://cloud.google.com/sdk/gcloud/reference/beta/compute/instances/ops-agents/policies/