### PR TITLE
fix: remove dependency to realpath for mac

### DIFF
--- a/modules/agent-policy/scripts/create-update-script.sh
+++ b/modules/agent-policy/scripts/create-update-script.sh
@@ -35,7 +35,7 @@ INSTANCES_JSON="$(echo "$8" | base64 --decode)"
 
 
 # include functions to build gcloud command
-SCRIPT_DIR="$( realpath "$( dirname "${BASH_SOURCE[0]}" )" )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
 UTILS_ABS_PATH="${SCRIPT_DIR}/script-utils.sh"
 # shellcheck disable=SC1090
 source "$UTILS_ABS_PATH"

--- a/modules/agent-policy/scripts/delete-script.sh
+++ b/modules/agent-policy/scripts/delete-script.sh
@@ -26,7 +26,7 @@ PROJECT_ID="$1"
 POLICY_ID="$2"
 
 # include functions to build gcloud command
-SCRIPT_DIR="$( realpath "$( dirname "${BASH_SOURCE[0]}" )" )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
 UTILS_ABS_PATH="${SCRIPT_DIR}/script-utils.sh"
 # shellcheck disable=SC1090
 source "$UTILS_ABS_PATH"


### PR DESCRIPTION
This patch removes the dependency to realpath because it is not installed by default on macosx. Fixes #15.