### PR TITLE
fix: update google provider to 3.x in examples

### DIFF
--- a/examples/agent_policy_detailed_example/main.tf
+++ b/examples/agent_policy_detailed_example/main.tf
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 2.0"
-}
+provider "google" {}
 
 module "agent_policy_detailed" {
   source      = "./../../modules/agent-policy"

--- a/examples/agent_policy_detailed_example/versions.tf
+++ b/examples/agent_policy_detailed_example/versions.tf
@@ -15,5 +15,12 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.25.0"
+    }
+  }
 }

--- a/examples/agent_policy_simple_example/main.tf
+++ b/examples/agent_policy_simple_example/main.tf
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 2.0"
-}
+provider "google" {}
 
 module "agent_policy_simple" {
   source     = "./../../modules/agent-policy"

--- a/examples/agent_policy_simple_example/versions.tf
+++ b/examples/agent_policy_simple_example/versions.tf
@@ -15,5 +15,12 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.25.0"
+    }
+  }
 }

--- a/examples/agent_policy_update_example/main.tf
+++ b/examples/agent_policy_update_example/main.tf
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 2.0"
-}
+provider "google" {}
 
 module "agent_policy_update" {
   source       = "./../../modules/agent-policy"

--- a/examples/agent_policy_update_example/versions.tf
+++ b/examples/agent_policy_update_example/versions.tf
@@ -15,5 +15,12 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.25.0"
+    }
+  }
 }

--- a/modules/agent-policy/versions.tf
+++ b/modules/agent-policy/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+provider "google" {}
+
+provider "google-beta" {}
+
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0"

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,13 +15,16 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
-}
+  required_version = ">= 0.13"
 
-provider "google" {
-  version = ">= 3.25.0"
-}
-
-provider "google-beta" {
-  version = ">= 3.54.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.25.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 3.54.0"
+    }
+  }
 }


### PR DESCRIPTION
Update google provider to 3.x in examples to match the requirements by the module.
This patch also uses terraform v0.13+ ways to specify versions.
The previous method has been [deprecated](https://www.terraform.io/docs/language/providers/configuration.html#version-an-older-way-to-manage-provider-versions).

Fixes #24.