### PR TITLE
Support Python 3

### DIFF
--- a/modules/agent-policy/scripts/script-utils.sh
+++ b/modules/agent-policy/scripts/script-utils.sh
@@ -78,7 +78,7 @@ function get_formatted_list_of_map() {
 function get_etag() {
     local python="python -c 'import json, sys;"
     python="$python json_dump = json.load(sys.stdin);"
-    python="$python print json_dump[\"etag\"]'"
+    python="$python print(json_dump[\"etag\"])'"
     formatted="$(echo "$1" | eval "$python")"
     echo "$formatted"
 }
@@ -311,7 +311,7 @@ function get_describe_command() {
     project_flag=$(get_flag "$project_flag_name" "$project_id")
 
     local command="gcloud $LAUNCH_STAGE compute instances ops-agents policies describe"
-    command="$command $policy_id$project_flag --quiet"
+    command="$command $policy_id$project_flag --quiet --format=json"
     echo "$command"
 }
 

--- a/test/agent-policy-tests/test-script-utils.bats
+++ b/test/agent-policy-tests/test-script-utils.bats
@@ -222,7 +222,7 @@ setup() {
 @test "Test get_describe_command" {
     local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies describe ops-agents-test-policy"
-    expected_command="$expected_command --project='test-project-id' --quiet"
+    expected_command="$expected_command --project='test-project-id' --quiet --format=json"
 
     run get_describe_command "$PROJECT_ID" "$POLICY_ID"
 


### PR DESCRIPTION
Support Python 3 for the Python code in `script-utils.sh`

This also adds the --format=json option to `get_describe_command` because the result is passed to `get_etag`, which expects json.

Fixes #26 

Note: The tests will fail until #25 is merged.