### PR TITLE
Add .terraform.lock.hcl to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ Session.vim
 *.tfstate
 *.tfstate.*
 
+# .terraform.lock.hcl files
+.terraform.lock.hcl
+
 # Crash log files
 crash.log
 


### PR DESCRIPTION
.terraform.lock.hcl was added in terraform 0.14 and should be ignored.

https://www.terraform.io/docs/language/dependency-lock.html