### PR TITLE
Use python3 explicitly and clean up python commands in script-utils.sh.

### DIFF
--- a/modules/agent-policy/scripts/script-utils.sh
+++ b/modules/agent-policy/scripts/script-utils.sh
@@ -31,12 +31,12 @@ LAUNCH_STAGE="beta"
 # Return:
 #   A well-formatted command line flag value for a list of strings
 function get_formatted_list_of_strings() {
-    local formatted
-    local python="python -c 'import json, sys;"
-    python="$python list_of_strings = json.load(sys.stdin);"
-    python="$python print (\",\".join(x for x in list_of_strings))'"
-    formatted="$(echo "$1" | eval "$python")"
-    echo "$formatted"
+    local -a python_cmd=(
+        'import json, sys;'
+        'list_of_strings = json.load(sys.stdin);'
+        'print (",".join(x for x in list_of_strings))'
+    )
+    echo "$1" | python3 -c "${python_cmd[*]}"
 }
 
 
@@ -45,14 +45,14 @@ function get_formatted_list_of_strings() {
 # Return:
 #   A well-formatted command line flag value for a list of objects
 function get_formatted_list_of_objects() {
-    local formatted
-    local python="python -c 'import json, sys;"
-    python="$python list_of_objs = json.load(sys.stdin);"
-    python="$python print (\";\".join(\",\".join([\"{}={}\".format(k.replace(\"_\", \"-\"),"
-    python="$python str(v).lower() if type(v) is bool else v) for k, v in obj.items()])"
-    python="$python for obj in list_of_objs))'"
-    formatted="$(echo "$1" | eval "$python")"
-    echo "$formatted"
+    local -a python_cmd=(
+        'import json, sys;'
+        'list_of_objs = json.load(sys.stdin);'
+        'print (";".join(",".join(["{}={}".format(k.replace("_", "-"),'
+        'str(v).lower() if type(v) is bool else v) for k, v in obj.items()])'
+        'for obj in list_of_objs))'
+    )
+    echo "$1" | python3 -c "${python_cmd[*]}"
 }
 
 
@@ -61,14 +61,13 @@ function get_formatted_list_of_objects() {
 # Return:
 #   A well-formatted command line flag value for a list of list of objects
 function get_formatted_list_of_map() {
-    local formatted
-    local python="python -c 'import json, sys;"
-    python="$python list_of_objs = json.load(sys.stdin);"
-    python="$python print (\";\".join(\",\".join([\"{}={}\".format(k, v)"
-    python="$python for k, v in obj.items()]) for obj in list_of_objs))'"
-    formatted="$(echo "$1" | eval "$python")"
-    echo "$formatted"
-
+    local -a python_cmd=(
+        'import json, sys;'
+        'list_of_objs = json.load(sys.stdin);'
+        'print (";".join(",".join(["{}={}".format(k, v)'
+        'for k, v in obj.items()]) for obj in list_of_objs))'
+    )
+    echo "$1" | python3 -c "${python_cmd[*]}"
 }
 
 # Params:
@@ -76,11 +75,12 @@ function get_formatted_list_of_map() {
 # Return:
 #   the etag in the given string
 function get_etag() {
-    local python="python -c 'import json, sys;"
-    python="$python json_dump = json.load(sys.stdin);"
-    python="$python print(json_dump[\"etag\"])'"
-    formatted="$(echo "$1" | eval "$python")"
-    echo "$formatted"
+    local -a python_cmd=(
+        'import json, sys;'
+        'json_dump = json.load(sys.stdin);'
+        'print(json_dump["etag"])'
+    )
+    echo "$1" | python3 -c "${python_cmd[*]}"
 }
 
 

--- a/modules/agent-policy/scripts/script-utils.sh
+++ b/modules/agent-policy/scripts/script-utils.sh
@@ -49,8 +49,8 @@ function get_formatted_list_of_objects() {
         'import json, sys;'
         'list_of_objs = json.load(sys.stdin);'
         'print (";".join(",".join(["{}={}".format(k.replace("_", "-"),'
-        'str(v).lower() if type(v) is bool else v) for k, v in obj.items()])'
-        'for obj in list_of_objs))'
+        'str(v).lower() if type(v) is bool else v)'
+        'for k, v in sorted(obj.items())]) for obj in list_of_objs))'
     )
     echo "$1" | python3 -c "${python_cmd[*]}"
 }
@@ -65,7 +65,7 @@ function get_formatted_list_of_map() {
         'import json, sys;'
         'list_of_objs = json.load(sys.stdin);'
         'print (";".join(",".join(["{}={}".format(k, v)'
-        'for k, v in obj.items()]) for obj in list_of_objs))'
+        'for k, v in sorted(obj.items())]) for obj in list_of_objs))'
     )
     echo "$1" | python3 -c "${python_cmd[*]}"
 }

--- a/test/agent-policy-tests/test-script-utils.bats
+++ b/test/agent-policy-tests/test-script-utils.bats
@@ -55,7 +55,7 @@ setup() {
     local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
-    expected_command="$expected_command --os-types='version=8,short-name=centos'"
+    expected_command="$expected_command --os-types='short-name=centos,version=8'"
     expected_command="$expected_command --project='test-project-id' --quiet"
 
     run get_create_command "$PROJECT_ID" "$POLICY_ID" \
@@ -77,7 +77,7 @@ setup() {
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --description='an example test policy'"
     expected_command="$expected_command --agent-rules='type=metrics'"
-    expected_command="$expected_command --os-types='version=8,short-name=centos'"
+    expected_command="$expected_command --os-types='short-name=centos,version=8'"
     expected_command="$expected_command --project='test-project-id' --quiet"
 
     run get_create_command "$PROJECT_ID" "$POLICY_ID" \
@@ -99,10 +99,10 @@ setup() {
 
     local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
-    expected_command="$expected_command --agent-rules='version=current-major,"
-    expected_command="${expected_command}type=logging,enable-autoupgrade=true,"
-    expected_command="${expected_command}package-state=installed;type=metrics'"
-    expected_command="$expected_command --os-types='version=8,short-name=centos'"
+    expected_command="$expected_command --agent-rules='enable-autoupgrade=true,"
+    expected_command="${expected_command}package-state=installed,type=logging,"
+    expected_command="${expected_command}version=current-major;type=metrics'"
+    expected_command="$expected_command --os-types='short-name=centos,version=8'"
     expected_command="$expected_command --project='test-project-id' --quiet"
 
     run get_create_command "$PROJECT_ID" "$POLICY_ID" \
@@ -124,9 +124,9 @@ setup() {
     local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
-    expected_command="$expected_command --group-labels='product=myapp,env=prod;"
-    expected_command="${expected_command}product=myapp,env=staging'"
-    expected_command="$expected_command --os-types='version=8,short-name=centos'"
+    expected_command="$expected_command --group-labels='env=prod,product=myapp;"
+    expected_command="${expected_command}env=staging,product=myapp'"
+    expected_command="$expected_command --os-types='short-name=centos,version=8'"
     expected_command="$expected_command --project='test-project-id' --quiet"
 
     run get_create_command "$PROJECT_ID" "$POLICY_ID" \
@@ -147,7 +147,7 @@ setup() {
     local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
-    expected_command="$expected_command --os-types='version=8,short-name=centos'"
+    expected_command="$expected_command --os-types='short-name=centos,version=8'"
     expected_command="$expected_command --zones='us-central1-c,"
     expected_command="${expected_command}asia-northeast2-b,europe-north1-b'"
     expected_command="$expected_command --project='test-project-id' --quiet"
@@ -170,7 +170,7 @@ setup() {
     local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies create ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
-    expected_command="$expected_command --os-types='version=8,short-name=centos'"
+    expected_command="$expected_command --os-types='short-name=centos,version=8'"
     expected_command="$expected_command --instances='zones/us-central1-a/"
     expected_command="${expected_command}instances/test-instance'"
     expected_command="$expected_command --project='test-project-id' --quiet"
@@ -199,7 +199,7 @@ setup() {
     local expected_command="gcloud beta compute instances ops-agents"
     expected_command="$expected_command policies update ops-agents-test-policy"
     expected_command="$expected_command --agent-rules='type=metrics'"
-    expected_command="$expected_command --os-types='version=8,short-name=centos'"
+    expected_command="$expected_command --os-types='short-name=centos,version=8'"
     expected_command="$expected_command --clear-group-labels"
     expected_command="$expected_command --clear-zones"
     expected_command="$expected_command --clear-instances"


### PR DESCRIPTION
This fixes the "python: command not found" error when python-is-python3 is not installed.