### PR TITLE
fix: create uuid as a resource to save value between runs

### DIFF
--- a/modules/agent-policy/main.tf
+++ b/modules/agent-policy/main.tf
@@ -31,7 +31,7 @@ module "gcloud-upsert" {
     ${base64encode(jsonencode(var.zones == null ? [] : var.zones))} \
     ${base64encode(jsonencode(var.instances == null ? [] : var.instances))}
     EOT
-  create_cmd_triggers   = { uuid = uuid() }
+  create_cmd_triggers   = { uuid = random_uuid.uuid.result }
 }
 
 module "gcloud-destroy" {
@@ -44,4 +44,7 @@ module "gcloud-destroy" {
 
   destroy_cmd_entrypoint = "${path.module}/scripts/delete-script.sh"
   destroy_cmd_body       = "${var.project_id} ${jsonencode(var.policy_id)}"
+}
+
+resource "random_uuid" "uuid" {
 }

--- a/modules/agent-policy/versions.tf
+++ b/modules/agent-policy/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = ">= 3.4"
     }
   }

--- a/modules/agent-policy/versions.tf
+++ b/modules/agent-policy/versions.tf
@@ -16,4 +16,9 @@
 
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/modules/agent-policy/versions.tf
+++ b/modules/agent-policy/versions.tf
@@ -19,6 +19,7 @@ terraform {
   required_providers {
     random = {
       source = "hashicorp/random"
+      version = ">= 3.4"
     }
   }
 }


### PR DESCRIPTION
fix: currently every run creates a new uuid for create_cmd_trigger causing recreate on every run. Use random_uuid to create a resource which will retain the value between runs.
This fixes #49 .