### PR TITLE
fix: use base64 -d instead of --decode for better base64 version compliance

### DIFF
--- a/modules/agent-policy/scripts/create-update-script.sh
+++ b/modules/agent-policy/scripts/create-update-script.sh
@@ -27,11 +27,11 @@ set -x # debug mode
 PROJECT_ID="$1"
 POLICY_ID="$2"
 DESCRIPTION="$3"
-AGENT_RULES_JSON="$(echo "$4" | base64 --decode)"
-GROUP_LABELS_JSON="$(echo "$5" | base64 --decode)"
-OS_TYPES_JSON="$(echo "$6" | base64 --decode)"
-ZONES_JSON="$(echo "$7" | base64 --decode)"
-INSTANCES_JSON="$(echo "$8" | base64 --decode)"
+AGENT_RULES_JSON="$(echo "$4" | base64 -d)"
+GROUP_LABELS_JSON="$(echo "$5" | base64 -d)"
+OS_TYPES_JSON="$(echo "$6" | base64 -d)"
+ZONES_JSON="$(echo "$7" | base64 -d)"
+INSTANCES_JSON="$(echo "$8" | base64 -d)"
 
 
 # include functions to build gcloud command


### PR DESCRIPTION
What it says on the label. Ran into this issue with an alpine-based CI pipeline. busybox's `base64` does not have the `--decode` flag, only `-d`. other versions of `base64` all seem to also support `-d`.