### PR TITLE
fix: Require OS version

### DIFF
--- a/modules/agent-policy/README.md
+++ b/modules/agent-policy/README.md
@@ -85,7 +85,7 @@ Functional examples are included in the [examples](./../../examples) directory.
 | description | The description of the policy. | `string` | `null` | no |
 | group\_labels | A list of label maps to filter instances to apply policies on. | `list(map(string))` | `null` | no |
 | instances | A list of instances to filter instances to apply the policy. | `list(string)` | `null` | no |
-| os\_types | A list of OS types to filter instances to apply the policy. | `list(any)` | n/a | yes |
+| os\_types | A list of OS types to filter instances to apply the policy. | <pre>list(object({<br>    short_name = string<br>    version    = string<br>  }))</pre> | n/a | yes |
 | policy\_id | The ID of the policy. | `string` | n/a | yes |
 | project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
 | zones | A list of zones to filter instances to apply the policy. | `list(string)` | `null` | no |

--- a/modules/agent-policy/variables.tf
+++ b/modules/agent-policy/variables.tf
@@ -52,12 +52,10 @@ variable "group_labels" {
 
 variable "os_types" {
   description = "A list of OS types to filter instances to apply the policy."
-  type        = list(any)
-
-  validation {
-    condition     = can([for os_type in var.os_types : os_type["short_name"]])
-    error_message = "Each os type must have a short_name."
-  }
+  type = list(object({
+    short_name = string
+    version    = string
+  }))
 }
 
 variable "zones" {


### PR DESCRIPTION
The underlying gcloud commands require the version to be provided, however the variable didn't:
```
ERROR: (gcloud.beta.compute.instances.ops-agents.policies.create) argument --os-types: Key [version] required in dict arg but not provided
```